### PR TITLE
fix Aqua test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,10 +9,6 @@ GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
 LabelledNumbers = "f856a3a6-4152-4ec4-b2a7-02c1a55d7993"
 
-[sources]
-GradedUnitRanges = {url = "https://github.com/ITensor/GradedUnitRanges.jl"}
-LabelledNumbers = {url = "https://github.com/ITensor/LabelledNumbers.jl"}
-
 [compat]
 Aqua = "0.8.9"
 BlockArrays = "1.2.0"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -6,4 +6,3 @@ SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 [sources]
 GradedUnitRanges = {url = "https://github.com/ITensor/GradedUnitRanges.jl"}
 LabelledNumbers = {url = "https://github.com/ITensor/LabelledNumbers.jl"}
-

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
-SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -4,7 +4,6 @@ using Aqua: Aqua
 using Test: @testset
 
 @testset "Code quality (Aqua.jl)" begin
-  # TODO: Reenable once dependencies are registered"
-  # Aqua.test_all(SymmetrySectors)
+  Aqua.test_all(SymmetrySectors)
 end
 end


### PR DESCRIPTION
This PR mimics https://github.com/ITensor/FusionTensors.jl/pull/3:
- remove test/Project.toml
- enable Aqua test
- not sure of this: remove sources from `Project.toml`. This was needed to get passing tests.

With this PR, `] test SymmetrySectors` passes all test in the local project.