### PR TITLE
use @constinferred in tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,10 +1,11 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
-SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 
 [compat]
 Aqua = "0.8.9"

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,6 +1,0 @@
-using SymmetrySectors: SymmetrySectors
-using Test: @test, @testset
-
-@testset "SymmetrySectors" begin
-  # Tests go here.
-end

--- a/test/test_fusion_rules.jl
+++ b/test/test_fusion_rules.jl
@@ -24,7 +24,7 @@ using TestExtras: @constinferred
     @test z0 ⊗ z0 == z0
     @test z0 ⊗ z1 == z1
     @test z1 ⊗ z1 == z0
-    @test (@constinferred z0 ⊗ z0) == z0  # no better way, see Julia PR 23426
+    @test (@constinferred z0 ⊗ z0) == z0
 
     q = TrivialSector()
     @test (@constinferred q ⊗ q) == q
@@ -49,7 +49,7 @@ using TestExtras: @constinferred
     @test q1 ⊗ q1 == U1(2)
     @test q1 ⊗ q2 == U1(3)
     @test q2 ⊗ q1 == U1(3)
-    @test (@constinferred q1 ⊗ q2) == q3  # no better way, see Julia PR 23426
+    @test (@constinferred q1 ⊗ q2) == q3
   end
 
   @testset "O2 fusion rules" begin

--- a/test/test_fusion_rules.jl
+++ b/test/test_fusion_rules.jl
@@ -13,7 +13,8 @@ using SymmetrySectors:
   block_dimensions,
   quantum_dimension,
   trivial
-using Test: @inferred, @test, @testset, @test_throws
+using Test: @test, @testset, @test_throws
+using TestExtras: @constinferred
 
 @testset "Simple SymmetrySector fusion rules" begin
   @testset "Z{2} fusion rules" begin
@@ -23,12 +24,12 @@ using Test: @inferred, @test, @testset, @test_throws
     @test z0 ⊗ z0 == z0
     @test z0 ⊗ z1 == z1
     @test z1 ⊗ z1 == z0
-    @test (@inferred z0 ⊗ z0) == z0  # no better way, see Julia PR 23426
+    @test (@constinferred z0 ⊗ z0) == z0  # no better way, see Julia PR 23426
 
     q = TrivialSector()
-    @test (@inferred q ⊗ q) == q
-    @test (@inferred q ⊗ z0) == z0
-    @test (@inferred z1 ⊗ q) == z1
+    @test (@constinferred q ⊗ q) == q
+    @test (@constinferred q ⊗ z0) == z0
+    @test (@constinferred z1 ⊗ q) == z1
 
     # using GradedUnitRanges interface
     @test space_isequal(fusion_product(z0, z0), gradedrange([z0 => 1]))
@@ -38,7 +39,7 @@ using Test: @inferred, @test, @testset, @test_throws
     @test space_isequal(fusion_product(z0), gradedrange([z0 => 1]))
     @test space_isequal(fusion_product(z0, z0, z0), gradedrange([z0 => 1]))
     @test space_isequal(fusion_product(z0, z0, z0, z0), gradedrange([z0 => 1]))
-    @test (@inferred block_dimensions(gradedrange([z1 => 1]))) == [1]
+    @test (@constinferred block_dimensions(gradedrange([z1 => 1]))) == [1]
   end
   @testset "U(1) fusion rules" begin
     q1 = U1(1)
@@ -48,7 +49,7 @@ using Test: @inferred, @test, @testset, @test_throws
     @test q1 ⊗ q1 == U1(2)
     @test q1 ⊗ q2 == U1(3)
     @test q2 ⊗ q1 == U1(3)
-    @test (@inferred q1 ⊗ q2) == q3  # no better way, see Julia PR 23426
+    @test (@constinferred q1 ⊗ q2) == q3  # no better way, see Julia PR 23426
   end
 
   @testset "O2 fusion rules" begin
@@ -58,23 +59,25 @@ using Test: @inferred, @test, @testset, @test_throws
     s1 = O2(1)
 
     q = TrivialSector()
-    @test space_isequal((@inferred s0e ⊗ q), gradedrange([s0e => 1]))
-    @test space_isequal((@inferred q ⊗ s0o), gradedrange([s0o => 1]))
+    @test space_isequal((@constinferred s0e ⊗ q), gradedrange([s0e => 1]))
+    @test space_isequal((@constinferred q ⊗ s0o), gradedrange([s0o => 1]))
 
-    @test space_isequal((@inferred s0e ⊗ s0e), gradedrange([s0e => 1]))
-    @test space_isequal((@inferred s0o ⊗ s0e), gradedrange([s0o => 1]))
-    @test space_isequal((@inferred s0o ⊗ s0e), gradedrange([s0o => 1]))
-    @test space_isequal((@inferred s0o ⊗ s0o), gradedrange([s0e => 1]))
+    @test space_isequal((@constinferred s0e ⊗ s0e), gradedrange([s0e => 1]))
+    @test space_isequal((@constinferred s0o ⊗ s0e), gradedrange([s0o => 1]))
+    @test space_isequal((@constinferred s0o ⊗ s0e), gradedrange([s0o => 1]))
+    @test space_isequal((@constinferred s0o ⊗ s0o), gradedrange([s0e => 1]))
 
-    @test space_isequal((@inferred s0e ⊗ s12), gradedrange([s12 => 1]))
-    @test space_isequal((@inferred s0o ⊗ s12), gradedrange([s12 => 1]))
-    @test space_isequal((@inferred s12 ⊗ s0e), gradedrange([s12 => 1]))
-    @test space_isequal((@inferred s12 ⊗ s0o), gradedrange([s12 => 1]))
-    @test space_isequal((@inferred s12 ⊗ s1), gradedrange([s12 => 1, O2(3//2) => 1]))
-    @test space_isequal((@inferred s12 ⊗ s12), gradedrange([s0o => 1, s0e => 1, s1 => 1]))
+    @test space_isequal((@constinferred s0e ⊗ s12), gradedrange([s12 => 1]))
+    @test space_isequal((@constinferred s0o ⊗ s12), gradedrange([s12 => 1]))
+    @test space_isequal((@constinferred s12 ⊗ s0e), gradedrange([s12 => 1]))
+    @test space_isequal((@constinferred s12 ⊗ s0o), gradedrange([s12 => 1]))
+    @test space_isequal((@constinferred s12 ⊗ s1), gradedrange([s12 => 1, O2(3//2) => 1]))
+    @test space_isequal(
+      (@constinferred s12 ⊗ s12), gradedrange([s0o => 1, s0e => 1, s1 => 1])
+    )
 
-    @test (@inferred quantum_dimension(s0o ⊗ s1)) == 2
-    @test (@inferred block_dimensions(s0o ⊗ s1)) == [2]
+    @test (@constinferred quantum_dimension(s0o ⊗ s1)) == 2
+    @test (@constinferred block_dimensions(s0o ⊗ s1)) == [2]
   end
 
   @testset "SU2 fusion rules" begin
@@ -88,9 +91,9 @@ using Test: @inferred, @test, @testset, @test_throws
     @test space_isequal(j2 ⊗ j2, gradedrange([j1 => 1, j3 => 1]))
     @test space_isequal(j2 ⊗ j3, gradedrange([j2 => 1, j4 => 1]))
     @test space_isequal(j3 ⊗ j3, gradedrange([j1 => 1, j3 => 1, j5 => 1]))
-    @test space_isequal((@inferred j1 ⊗ j2), gradedrange([j2 => 1]))
-    @test (@inferred quantum_dimension(j1 ⊗ j2)) == 2
-    @test (@inferred block_dimensions(j1 ⊗ j2)) == [2]
+    @test space_isequal((@constinferred j1 ⊗ j2), gradedrange([j2 => 1]))
+    @test (@constinferred quantum_dimension(j1 ⊗ j2)) == 2
+    @test (@constinferred block_dimensions(j1 ⊗ j2)) == [2]
 
     @test space_isequal(fusion_product(j2), gradedrange([j2 => 1]))
     @test space_isequal(fusion_product(j2, j1), gradedrange([j2 => 1]))
@@ -104,8 +107,8 @@ using Test: @inferred, @test, @testset, @test_throws
     @test space_isequal(ı ⊗ ı, gradedrange([ı => 1]))
     @test space_isequal(ı ⊗ τ, gradedrange([τ => 1]))
     @test space_isequal(τ ⊗ ı, gradedrange([τ => 1]))
-    @test space_isequal((@inferred τ ⊗ τ), gradedrange([ı => 1, τ => 1]))
-    @test (@inferred quantum_dimension(gradedrange([ı => 1, ı => 1]))) == 2.0
+    @test space_isequal((@constinferred τ ⊗ τ), gradedrange([ı => 1, τ => 1]))
+    @test (@constinferred quantum_dimension(gradedrange([ı => 1, ı => 1]))) == 2.0
   end
 
   @testset "Ising fusion rules" begin
@@ -122,8 +125,8 @@ using Test: @inferred, @test, @testset, @test_throws
     @test space_isequal(σ ⊗ ψ, gradedrange([σ => 1]))
     @test space_isequal(ψ ⊗ σ, gradedrange([σ => 1]))
     @test space_isequal(ψ ⊗ ψ, gradedrange([ı => 1]))
-    @test space_isequal((@inferred ψ ⊗ ψ), gradedrange([ı => 1]))
-    @test (@inferred quantum_dimension(σ ⊗ σ)) == 2.0
+    @test space_isequal((@constinferred ψ ⊗ ψ), gradedrange([ı => 1]))
+    @test (@constinferred quantum_dimension(σ ⊗ σ)) == 2.0
   end
 end
 @testset "Gradedrange fusion rules" begin
@@ -139,7 +142,7 @@ end
     g2 = gradedrange([U1(-2) => 2, U1(0) => 1, U1(1) => 2])
 
     @test space_isequal(flip(dual(g1)), gradedrange([U1(1) => 1, U1(0) => 1, U1(-1) => 2]))
-    @test (@inferred block_dimensions(g1)) == [1, 1, 2]
+    @test (@constinferred block_dimensions(g1)) == [1, 1, 2]
 
     gt = gradedrange([
       U1(-3) => 2,
@@ -155,8 +158,8 @@ end
     gf = gradedrange([
       U1(-3) => 2, U1(-2) => 2, U1(-1) => 5, U1(0) => 3, U1(1) => 4, U1(2) => 4
     ])
-    @test space_isequal((@inferred tensor_product(g1, g2)), gt)
-    @test space_isequal((@inferred fusion_product(g1, g2)), gf)
+    @test space_isequal((@constinferred tensor_product(g1, g2)), gt)
+    @test space_isequal((@constinferred fusion_product(g1, g2)), gf)
 
     gtd1 = gradedrange([
       U1(-1) => 2,
@@ -172,8 +175,8 @@ end
     gfd1 = gradedrange([
       U1(-3) => 4, U1(-2) => 2, U1(-1) => 4, U1(0) => 5, U1(1) => 3, U1(2) => 2
     ])
-    @test space_isequal((@inferred tensor_product(dual(g1), g2)), gtd1)
-    @test space_isequal((@inferred fusion_product(dual(g1), g2)), gfd1)
+    @test space_isequal((@constinferred tensor_product(dual(g1), g2)), gtd1)
+    @test space_isequal((@constinferred fusion_product(dual(g1), g2)), gfd1)
 
     gtd2 = gradedrange([
       U1(1) => 2,
@@ -189,8 +192,8 @@ end
     gfd2 = gradedrange([
       U1(-2) => 2, U1(-1) => 3, U1(0) => 5, U1(1) => 4, U1(2) => 2, U1(3) => 4
     ])
-    @test space_isequal((@inferred tensor_product(g1, dual(g2))), gtd2)
-    @test space_isequal((@inferred fusion_product(g1, dual(g2))), gfd2)
+    @test space_isequal((@constinferred tensor_product(g1, dual(g2))), gtd2)
+    @test space_isequal((@constinferred fusion_product(g1, dual(g2))), gfd2)
 
     gtd = gradedrange([
       U1(3) => 2,
@@ -206,8 +209,8 @@ end
     gfd = gradedrange([
       U1(-2) => 4, U1(-1) => 4, U1(0) => 3, U1(1) => 5, U1(2) => 2, U1(3) => 2
     ])
-    @test space_isequal((@inferred tensor_product(dual(g1), dual(g2))), gtd)
-    @test space_isequal((@inferred fusion_product(dual(g1), dual(g2))), gfd)
+    @test space_isequal((@constinferred tensor_product(dual(g1), dual(g2))), gtd)
+    @test space_isequal((@constinferred fusion_product(dual(g1), dual(g2))), gfd)
 
     # test different (non-product) sectors cannot be fused
     @test_throws MethodError fusion_product(gradedrange([Z{2}(0) => 1]), g1)
@@ -235,10 +238,10 @@ end
 
     @test space_isequal(dual(flip(g3)), g3)  # trivial for SU(2)
     @test space_isequal(
-      (@inferred fusion_product(g3, g4)),
+      (@constinferred fusion_product(g3, g4)),
       gradedrange([SU2(0) => 4, SU2(1//2) => 6, SU2(1) => 6, SU2(3//2) => 5, SU2(2) => 2]),
     )
-    @test (@inferred block_dimensions(g3)) == [1, 4, 3]
+    @test (@constinferred block_dimensions(g3)) == [1, 4, 3]
 
     # test dual on non self-conjugate non-abelian representations
     s1 = SU{3}((0, 0))
@@ -268,13 +271,13 @@ end
   @testset "Mixed GradedUnitRange - Sector fusion rules" begin
     g1 = gradedrange([U1(1) => 1, U1(2) => 2])
     g2 = gradedrange([U1(2) => 1, U1(3) => 2])
-    @test space_isequal((@inferred fusion_product(g1, U1(1))), g2)
-    @test space_isequal((@inferred fusion_product(U1(1), g1)), g2)
+    @test space_isequal((@constinferred fusion_product(g1, U1(1))), g2)
+    @test space_isequal((@constinferred fusion_product(U1(1), g1)), g2)
 
     g3 = gradedrange([SU2(0) => 1, SU2(1//2) => 2])
     g4 = gradedrange([SU2(0) => 2, SU2(1//2) => 1, SU2(1) => 2])
-    @test space_isequal((@inferred fusion_product(g3, SU2(1//2))), g4)
-    @test space_isequal((@inferred fusion_product(SU2(1//2), g3)), g4)
+    @test space_isequal((@constinferred fusion_product(g3, SU2(1//2))), g4)
+    @test space_isequal((@constinferred fusion_product(SU2(1//2), g3)), g4)
 
     # test different simple sectors cannot be fused
     @test_throws MethodError Z{2}(0) ⊗ U1(1)

--- a/test/test_sector_product.jl
+++ b/test/test_sector_product.jl
@@ -14,48 +14,49 @@ using SymmetrySectors:
   arguments,
   trivial
 using GradedUnitRanges: dual, fusion_product, space_isequal, gradedrange
-using Test: @inferred, @test, @testset, @test_throws
+using Test: @test, @testset, @test_throws
+using TestExtras: @constinferred
 
 @testset "Test Ordered Products" begin
   @testset "Ordered Constructor" begin
     s = SectorProduct(U1(1))
     @test length(arguments(s)) == 1
-    @test (@inferred quantum_dimension(s)) == 1
-    @test (@inferred dual(s)) == SectorProduct(U1(-1))
+    @test (@constinferred quantum_dimension(s)) == 1
+    @test (@constinferred dual(s)) == SectorProduct(U1(-1))
     @test arguments(s)[1] == U1(1)
-    @test (@inferred trivial(s)) == SectorProduct(U1(0))
+    @test (@constinferred trivial(s)) == SectorProduct(U1(0))
 
     s = SectorProduct(U1(1), U1(2))
     @test length(arguments(s)) == 2
-    @test (@inferred quantum_dimension(s)) == 1
-    @test (@inferred dual(s)) == SectorProduct(U1(-1), U1(-2))
+    @test (@constinferred quantum_dimension(s)) == 1
+    @test (@constinferred dual(s)) == SectorProduct(U1(-1), U1(-2))
     @test arguments(s)[1] == U1(1)
     @test arguments(s)[2] == U1(2)
-    @test (@inferred trivial(s)) == SectorProduct(U1(0), U1(0))
+    @test (@constinferred trivial(s)) == SectorProduct(U1(0), U1(0))
 
     s = U1(1) × SU2(1//2) × U1(3)
     @test length(arguments(s)) == 3
-    @test (@inferred quantum_dimension(s)) == 2
-    @test (@inferred dual(s)) == U1(-1) × SU2(1//2) × U1(-3)
+    @test (@constinferred quantum_dimension(s)) == 2
+    @test (@constinferred dual(s)) == U1(-1) × SU2(1//2) × U1(-3)
     @test arguments(s)[1] == U1(1)
     @test arguments(s)[2] == SU2(1//2)
     @test arguments(s)[3] == U1(3)
-    @test (@inferred trivial(s)) == SectorProduct(U1(0), SU2(0), U1(0))
+    @test (@constinferred trivial(s)) == SectorProduct(U1(0), SU2(0), U1(0))
 
     s = U1(3) × SU2(1//2) × Fib("τ")
     @test length(arguments(s)) == 3
-    @test (@inferred quantum_dimension(s)) == 1.0 + √5
+    @test (@constinferred quantum_dimension(s)) == 1.0 + √5
     @test dual(s) == U1(-3) × SU2(1//2) × Fib("τ")
     @test arguments(s)[1] == U1(3)
     @test arguments(s)[2] == SU2(1//2)
     @test arguments(s)[3] == Fib("τ")
-    @test (@inferred trivial(s)) == SectorProduct(U1(0), SU2(0), Fib("1"))
+    @test (@constinferred trivial(s)) == SectorProduct(U1(0), SU2(0), Fib("1"))
 
     s = TrivialSector() × U1(3) × SU2(1 / 2)
     @test length(arguments(s)) == 3
-    @test (@inferred quantum_dimension(s)) == 2
+    @test (@constinferred quantum_dimension(s)) == 2
     @test dual(s) == TrivialSector() × U1(-3) × SU2(1//2)
-    @test (@inferred trivial(s)) == SectorProduct(TrivialSector(), U1(0), SU2(0))
+    @test (@constinferred trivial(s)) == SectorProduct(TrivialSector(), U1(0), SU2(0))
     @test s > trivial(s)
   end
 
@@ -80,7 +81,7 @@ using Test: @inferred, @test, @testset, @test_throws
 
   @testset "Quantum dimension and GradedUnitRange" begin
     g = gradedrange([(U1(0) × Z{2}(0)) => 1, (U1(1) × Z{2}(0)) => 2])  # abelian
-    @test (@inferred quantum_dimension(g)) == 3
+    @test (@constinferred quantum_dimension(g)) == 3
 
     g = gradedrange([  # non-abelian
       (SU2(0) × SU2(0)) => 1,
@@ -88,29 +89,29 @@ using Test: @inferred, @test, @testset, @test_throws
       (SU2(0) × SU2(1)) => 1,
       (SU2(1) × SU2(1)) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 16
-    @test (@inferred block_dimensions(g)) == [1, 3, 3, 9]
+    @test (@constinferred quantum_dimension(g)) == 16
+    @test (@constinferred block_dimensions(g)) == [1, 3, 3, 9]
 
     # mixed group
     g = gradedrange([(U1(2) × SU2(0) × Z{2}(0)) => 1, (U1(2) × SU2(1) × Z{2}(0)) => 1])
-    @test (@inferred quantum_dimension(g)) == 4
-    @test (@inferred block_dimensions(g)) == [1, 3]
+    @test (@constinferred quantum_dimension(g)) == 4
+    @test (@constinferred block_dimensions(g)) == [1, 3]
     g = gradedrange([(SU2(0) × U1(0) × SU2(1//2)) => 1, (SU2(0) × U1(1) × SU2(1//2)) => 1])
-    @test (@inferred quantum_dimension(g)) == 4
-    @test (@inferred block_dimensions(g)) == [2, 2]
+    @test (@constinferred quantum_dimension(g)) == 4
+    @test (@constinferred block_dimensions(g)) == [2, 2]
 
     # NonGroupCategory
     g_fib = gradedrange([(Fib("1") × Fib("1")) => 1])
     g_ising = gradedrange([(Ising("1") × Ising("1")) => 1])
-    @test (@inferred quantum_dimension((Fib("1") × Fib("1")))) == 1.0
-    @test (@inferred quantum_dimension(g_fib)) == 1.0
-    @test (@inferred quantum_dimension(g_ising)) == 1.0
-    @test (@inferred quantum_dimension((Ising("1") × Ising("1")))) == 1.0
-    @test (@inferred block_dimensions(g_fib)) == [1.0]
-    @test (@inferred block_dimensions(g_ising)) == [1.0]
+    @test (@constinferred quantum_dimension((Fib("1") × Fib("1")))) == 1.0
+    @test (@constinferred quantum_dimension(g_fib)) == 1.0
+    @test (@constinferred quantum_dimension(g_ising)) == 1.0
+    @test (@constinferred quantum_dimension((Ising("1") × Ising("1")))) == 1.0
+    @test (@constinferred block_dimensions(g_fib)) == [1.0]
+    @test (@constinferred block_dimensions(g_ising)) == [1.0]
 
-    @test (@inferred quantum_dimension(U1(1) × Fib("1"))) == 1.0
-    @test (@inferred quantum_dimension(gradedrange([U1(1) × Fib("1") => 1]))) == 1.0
+    @test (@constinferred quantum_dimension(U1(1) × Fib("1"))) == 1.0
+    @test (@constinferred quantum_dimension(gradedrange([U1(1) × Fib("1") => 1]))) == 1.0
 
     # mixed product Abelian / NonAbelian / NonGroup
     g = gradedrange([
@@ -119,8 +120,8 @@ using Test: @inferred, @test, @testset, @test_throws
       (U1(2) × SU2(0) × Ising("ψ")) => 1,
       (U1(2) × SU2(1) × Ising("ψ")) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 8.0
-    @test (@inferred block_dimensions(g)) == [1.0, 3.0, 1.0, 3.0]
+    @test (@constinferred quantum_dimension(g)) == 8.0
+    @test (@constinferred block_dimensions(g)) == [1.0, 3.0, 1.0, 3.0]
 
     ϕ = (1 + √5) / 2
     g = gradedrange([
@@ -129,16 +130,16 @@ using Test: @inferred, @test, @testset, @test_throws
       (Fib("τ") × SU2(0) × U1(2)) => 1,
       (Fib("τ") × SU2(1) × U1(2)) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 4.0 + 4.0ϕ
-    @test (@inferred block_dimensions(g)) == [1.0, 3.0, 1.0ϕ, 3.0ϕ]
+    @test (@constinferred quantum_dimension(g)) == 4.0 + 4.0ϕ
+    @test (@constinferred block_dimensions(g)) == [1.0, 3.0, 1.0ϕ, 3.0ϕ]
   end
 
   @testset "Fusion of Abelian products" begin
     p1 = SectorProduct(U1(1))
     p2 = SectorProduct(U1(2))
-    @test (@inferred p1 ⊗ TrivialSector()) == p1
-    @test (@inferred TrivialSector() ⊗ p2) == p2
-    @test (@inferred p1 ⊗ p2) == SectorProduct(U1(3))
+    @test (@constinferred p1 ⊗ TrivialSector()) == p1
+    @test (@constinferred TrivialSector() ⊗ p2) == p2
+    @test (@constinferred p1 ⊗ p2) == SectorProduct(U1(3))
 
     p11 = U1(1) × U1(1)
     @test p11 ⊗ p11 == U1(2) × U1(2)
@@ -155,10 +156,10 @@ using Test: @inferred, @test, @testset, @test_throws
     p0 = SectorProduct(SU2(0))
     ph = SectorProduct(SU2(1//2))
     @test space_isequal(
-      (@inferred p0 ⊗ TrivialSector()), gradedrange([SectorProduct(SU2(0)) => 1])
+      (@constinferred p0 ⊗ TrivialSector()), gradedrange([SectorProduct(SU2(0)) => 1])
     )
     @test space_isequal(
-      (@inferred TrivialSector() ⊗ ph), gradedrange([SectorProduct(SU2(1//2)) => 1])
+      (@constinferred TrivialSector() ⊗ ph), gradedrange([SectorProduct(SU2(1//2)) => 1])
     )
 
     phh = SU2(1//2) × SU2(1//2)
@@ -249,16 +250,16 @@ using Test: @inferred, @test, @testset, @test_throws
     @test SectorProduct(U1(1) × U1(0)) ⊗ SectorProduct(U1(1)) ==
       SectorProduct(U1(2) × U1(0))
     @test space_isequal(
-      (@inferred SectorProduct(SU2(0) × SU2(0)) ⊗ SectorProduct(SU2(1))),
+      (@constinferred SectorProduct(SU2(0) × SU2(0)) ⊗ SectorProduct(SU2(1))),
       gradedrange([SectorProduct(SU2(1) × SU2(0)) => 1]),
     )
 
     @test space_isequal(
-      (@inferred SectorProduct(SU2(1) × U1(1)) ⊗ SectorProduct(SU2(0))),
+      (@constinferred SectorProduct(SU2(1) × U1(1)) ⊗ SectorProduct(SU2(0))),
       gradedrange([SectorProduct(SU2(1) × U1(1)) => 1]),
     )
     @test space_isequal(
-      (@inferred SectorProduct(U1(1) × SU2(1)) ⊗ SectorProduct(U1(2))),
+      (@constinferred SectorProduct(U1(1) × SU2(1)) ⊗ SectorProduct(U1(2))),
       gradedrange([SectorProduct(U1(3) × SU2(1)) => 1]),
     )
 
@@ -286,24 +287,24 @@ end
     @test length(arguments(s)) == 2
     @test arguments(s)[:A] == U1(1)
     @test arguments(s)[:B] == Z{2}(0)
-    @test (@inferred quantum_dimension(s)) == 1
-    @test (@inferred dual(s)) == (A=U1(-1),) × (B=Z{2}(0),)
-    @test (@inferred trivial(s)) == (A=U1(0),) × (B=Z{2}(0),)
+    @test (@constinferred quantum_dimension(s)) == 1
+    @test (@constinferred dual(s)) == (A=U1(-1),) × (B=Z{2}(0),)
+    @test (@constinferred trivial(s)) == (A=U1(0),) × (B=Z{2}(0),)
 
     s = (A=U1(1),) × (B=SU2(2),)
     @test length(arguments(s)) == 2
     @test arguments(s)[:A] == U1(1)
     @test arguments(s)[:B] == SU2(2)
-    @test (@inferred quantum_dimension(s)) == 5
-    @test (@inferred dual(s)) == (A=U1(-1),) × (B=SU2(2),)
-    @test (@inferred trivial(s)) == (A=U1(0),) × (B=SU2(0),)
+    @test (@constinferred quantum_dimension(s)) == 5
+    @test (@constinferred dual(s)) == (A=U1(-1),) × (B=SU2(2),)
+    @test (@constinferred trivial(s)) == (A=U1(0),) × (B=SU2(0),)
     @test s == (B=SU2(2),) × (A=U1(1),)
 
     s = s × (C=Ising("ψ"),)
     @test length(arguments(s)) == 3
     @test arguments(s)[:C] == Ising("ψ")
-    @test (@inferred quantum_dimension(s)) == 5.0
-    @test (@inferred dual(s)) == (A=U1(-1),) × (B=SU2(2),) × (C=Ising("ψ"),)
+    @test (@constinferred quantum_dimension(s)) == 5.0
+    @test (@constinferred dual(s)) == (A=U1(-1),) × (B=SU2(2),) × (C=Ising("ψ"),)
 
     s1 = (A=U1(1),) × (B=Z{2}(0),)
     s2 = (A=U1(1),) × (C=Z{2}(0),)
@@ -315,15 +316,15 @@ end
     @test length(arguments(s)) == 1
     @test arguments(s)[:A] == U1(2)
     @test s == SectorProduct(; A=U1(2))
-    @test (@inferred quantum_dimension(s)) == 1
-    @test (@inferred dual(s)) == SectorProduct("A" => U1(-2))
-    @test (@inferred trivial(s)) == SectorProduct(; A=U1(0))
+    @test (@constinferred quantum_dimension(s)) == 1
+    @test (@constinferred dual(s)) == SectorProduct("A" => U1(-2))
+    @test (@constinferred trivial(s)) == SectorProduct(; A=U1(0))
 
     s = SectorProduct("B" => Ising("ψ"), :C => Z{2}(1))
     @test length(arguments(s)) == 2
     @test arguments(s)[:B] == Ising("ψ")
     @test arguments(s)[:C] == Z{2}(1)
-    @test (@inferred quantum_dimension(s)) == 1.0
+    @test (@constinferred quantum_dimension(s)) == 1.0
   end
 
   @testset "Comparisons with unspecified labels" begin
@@ -351,7 +352,7 @@ end
     g = gradedrange([
       SectorProduct(; A=U1(0), B=Z{2}(0)) => 1, SectorProduct(; A=U1(1), B=Z{2}(0)) => 2
     ])  # abelian
-    @test (@inferred quantum_dimension(g)) == 3
+    @test (@constinferred quantum_dimension(g)) == 3
 
     g = gradedrange([  # non-abelian
       SectorProduct(; A=SU2(0), B=SU2(0)) => 1,
@@ -359,25 +360,25 @@ end
       SectorProduct(; A=SU2(0), B=SU2(1)) => 1,
       SectorProduct(; A=SU2(1), B=SU2(1)) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 16
+    @test (@constinferred quantum_dimension(g)) == 16
 
     # mixed group
     g = gradedrange([
       SectorProduct(; A=U1(2), B=SU2(0), C=Z{2}(0)) => 1,
       SectorProduct(; A=U1(2), B=SU2(1), C=Z{2}(0)) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 4
+    @test (@constinferred quantum_dimension(g)) == 4
     g = gradedrange([
       SectorProduct(; A=SU2(0), B=Z{2}(0), C=SU2(1//2)) => 1,
       SectorProduct(; A=SU2(0), B=Z{2}(1), C=SU2(1//2)) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 4
+    @test (@constinferred quantum_dimension(g)) == 4
 
     # non group sectors
     g_fib = gradedrange([SectorProduct(; A=Fib("1"), B=Fib("1")) => 1])
     g_ising = gradedrange([SectorProduct(; A=Ising("1"), B=Ising("1")) => 1])
-    @test (@inferred quantum_dimension(g_fib)) == 1.0
-    @test (@inferred quantum_dimension(g_ising)) == 1.0
+    @test (@constinferred quantum_dimension(g_fib)) == 1.0
+    @test (@constinferred quantum_dimension(g_ising)) == 1.0
 
     # mixed product Abelian / NonAbelian / NonGroup
     g = gradedrange([
@@ -386,7 +387,7 @@ end
       SectorProduct(; A=U1(2), B=SU2(0), C=Ising("ψ")) => 1,
       SectorProduct(; A=U1(2), B=SU2(1), C=Ising("ψ")) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 8.0
+    @test (@constinferred quantum_dimension(g)) == 8.0
 
     g = gradedrange([
       SectorProduct(; A=Fib("1"), B=SU2(0), C=U1(2)) => 1,
@@ -394,7 +395,7 @@ end
       SectorProduct(; A=Fib("τ"), B=SU2(0), C=U1(2)) => 1,
       SectorProduct(; A=Fib("τ"), B=SU2(1), C=U1(2)) => 1,
     ])
-    @test (@inferred quantum_dimension(g)) == 4.0 + 4.0quantum_dimension(Fib("τ"))
+    @test (@constinferred quantum_dimension(g)) == 4.0 + 4.0quantum_dimension(Fib("τ"))
   end
 
   @testset "Fusion of Abelian products" begin
@@ -403,18 +404,18 @@ end
     q01 = SectorProduct(; B=U1(1))
     q11 = SectorProduct(; A=U1(1), B=U1(1))
 
-    @test (@inferred q10 ⊗ q10) == SectorProduct(; A=U1(2))
-    @test (@inferred q01 ⊗ q00) == q01
-    @test (@inferred q00 ⊗ q01) == q01
-    @test (@inferred q10 ⊗ q01) == q11
+    @test (@constinferred q10 ⊗ q10) == SectorProduct(; A=U1(2))
+    @test (@constinferred q01 ⊗ q00) == q01
+    @test (@constinferred q00 ⊗ q01) == q01
+    @test (@constinferred q10 ⊗ q01) == q11
     @test q11 ⊗ q11 == SectorProduct(; A=U1(2), B=U1(2))
 
     s11 = SectorProduct(; A=U1(1), B=Z{2}(1))
     s10 = SectorProduct(; A=U1(1))
     s01 = SectorProduct(; B=Z{2}(1))
-    @test (@inferred s01 ⊗ q00) == s01
-    @test (@inferred q00 ⊗ s01) == s01
-    @test (@inferred s10 ⊗ s01) == s11
+    @test (@constinferred s01 ⊗ q00) == s01
+    @test (@constinferred q00 ⊗ s01) == s01
+    @test (@constinferred s10 ⊗ s01) == s11
     @test s11 ⊗ s11 == SectorProduct(; A=U1(2), B=Z{2}(0))
   end
 
@@ -425,12 +426,12 @@ end
     phab = SectorProduct(; A=SU2(1//2), B=SU2(1//2))
 
     @test space_isequal(
-      (@inferred pha ⊗ pha),
+      (@constinferred pha ⊗ pha),
       gradedrange([SectorProduct(; A=SU2(0)) => 1, SectorProduct(; A=SU2(1)) => 1]),
     )
-    @test space_isequal((@inferred pha ⊗ p0), gradedrange([pha => 1]))
-    @test space_isequal((@inferred p0 ⊗ phb), gradedrange([phb => 1]))
-    @test space_isequal((@inferred pha ⊗ phb), gradedrange([phab => 1]))
+    @test space_isequal((@constinferred pha ⊗ p0), gradedrange([pha => 1]))
+    @test space_isequal((@constinferred p0 ⊗ phb), gradedrange([phb => 1]))
+    @test space_isequal((@constinferred pha ⊗ phb), gradedrange([phab => 1]))
 
     @test space_isequal(
       phab ⊗ phab,
@@ -485,7 +486,7 @@ end
 
     @test space_isequal(q1h ⊗ q1h, gradedrange([q20 => 1, q21 => 1]))
     @test space_isequal(q10 ⊗ q1h, gradedrange([q2h => 1]))
-    @test space_isequal((@inferred q0h ⊗ q1h), gradedrange([q10 => 1, q11 => 1]))
+    @test space_isequal((@constinferred q0h ⊗ q1h), gradedrange([q10 => 1, q11 => 1]))
     @test space_isequal(q11 ⊗ q11, gradedrange([q20 => 1, q21 => 1, q22 => 1]))
   end
 
@@ -565,41 +566,42 @@ end
     @test !(s < SectorProduct())
     @test !(s < SectorProduct(;))
 
-    @test (@inferred s × SectorProduct(())) == s
-    @test (@inferred s × SectorProduct((;))) == s
-    @test (@inferred s ⊗ SectorProduct(())) == s
-    @test (@inferred s ⊗ SectorProduct((;))) == s
+    @test (@constinferred s × SectorProduct(())) == s
+    @test (@constinferred s × SectorProduct((;))) == s
+    @test (@constinferred s ⊗ SectorProduct(())) == s
+    @test (@constinferred s ⊗ SectorProduct((;))) == s
 
-    @test (@inferred dual(s)) == s
-    @test (@inferred trivial(s)) == s
-    @test (@inferred quantum_dimension(s)) == 1
+    @test (@constinferred dual(s)) == s
+    @test (@constinferred trivial(s)) == s
+    @test (@constinferred quantum_dimension(s)) == 1
 
     g0 = gradedrange([s => 2])
-    @test space_isequal((@inferred fusion_product(g0, g0)), gradedrange([s => 4]))
+    @test space_isequal((@constinferred fusion_product(g0, g0)), gradedrange([s => 4]))
 
-    @test (@inferred s × U1(1)) == st1
-    @test (@inferred U1(1) × s) == st1
-    @test (@inferred s × st1) == st1
-    @test (@inferred st1 × s) == st1
-    @test (@inferred s × sA1) == sA1
-    @test (@inferred sA1 × s) == sA1
+    @test (@constinferred s × U1(1)) == st1
+    @test (@constinferred U1(1) × s) == st1
+    @test (@constinferred s × st1) == st1
+    @test (@constinferred st1 × s) == st1
+    @test (@constinferred s × sA1) == sA1
+    @test (@constinferred sA1 × s) == sA1
 
-    @test (@inferred U1(1) ⊗ s) == st1
-    @test (@inferred s ⊗ U1(1)) == st1
-    @test (@inferred SU2(0) ⊗ s) == gradedrange([SectorProduct(SU2(0)) => 1])
-    @test (@inferred s ⊗ SU2(0)) == gradedrange([SectorProduct(SU2(0)) => 1])
-    @test (@inferred Fib("τ") ⊗ s) == gradedrange([SectorProduct(Fib("τ")) => 1])
-    @test (@inferred s ⊗ Fib("τ")) == gradedrange([SectorProduct(Fib("τ")) => 1])
+    @test (@constinferred U1(1) ⊗ s) == st1
+    @test (@constinferred s ⊗ U1(1)) == st1
+    @test (@constinferred SU2(0) ⊗ s) == gradedrange([SectorProduct(SU2(0)) => 1])
+    @test (@constinferred s ⊗ SU2(0)) == gradedrange([SectorProduct(SU2(0)) => 1])
+    @test (@constinferred Fib("τ") ⊗ s) == gradedrange([SectorProduct(Fib("τ")) => 1])
+    @test (@constinferred s ⊗ Fib("τ")) == gradedrange([SectorProduct(Fib("τ")) => 1])
 
-    @test (@inferred st1 ⊗ s) == st1
-    @test (@inferred SectorProduct(SU2(0)) ⊗ s) == gradedrange([SectorProduct(SU2(0)) => 1])
-    @test (@inferred SectorProduct(Fib("τ"), SU2(1), U1(2)) ⊗ s) ==
+    @test (@constinferred st1 ⊗ s) == st1
+    @test (@constinferred SectorProduct(SU2(0)) ⊗ s) ==
+      gradedrange([SectorProduct(SU2(0)) => 1])
+    @test (@constinferred SectorProduct(Fib("τ"), SU2(1), U1(2)) ⊗ s) ==
       gradedrange([SectorProduct(Fib("τ"), SU2(1), U1(2)) => 1])
 
-    @test (@inferred sA1 ⊗ s) == sA1
-    @test (@inferred SectorProduct(; A=SU2(0)) ⊗ s) ==
+    @test (@constinferred sA1 ⊗ s) == sA1
+    @test (@constinferred SectorProduct(; A=SU2(0)) ⊗ s) ==
       gradedrange([SectorProduct(; A=SU2(0)) => 1])
-    @test (@inferred SectorProduct(; A=Fib("τ"), B=SU2(1), C=U1(2)) ⊗ s) ==
+    @test (@constinferred SectorProduct(; A=Fib("τ"), B=SU2(1), C=U1(2)) ⊗ s) ==
       gradedrange([SectorProduct(; A=Fib("τ"), B=SU2(1), C=U1(2)) => 1])
 
     # Empty behaves as empty NamedTuple

--- a/test/test_simple_sectors.jl
+++ b/test/test_simple_sectors.jl
@@ -12,14 +12,16 @@ using SymmetrySectors:
   fundamental,
   istrivial,
   trivial
-using Test: @inferred, @test, @testset, @test_throws
+using Test: @test, @testset, @test_throws
+using TestExtras: @constinferred
+
 @testset "Test SymmetrySectors Types" begin
   @testset "TrivialSector" begin
     q = TrivialSector()
 
     @test sector_type(q) === TrivialSector
     @test sector_type(typeof(q)) === TrivialSector
-    @test (@inferred quantum_dimension(q)) == 1
+    @test (@constinferred quantum_dimension(q)) == 1
     @test q == q
     @test trivial(q) == q
     @test istrivial(q)
@@ -37,7 +39,7 @@ using Test: @inferred, @test, @testset, @test_throws
     @test sector_type(typeof(q1)) === U1{Int}
     @test quantum_dimension(q1) == 1
     @test quantum_dimension(q2) == 1
-    @test (@inferred quantum_dimension(q1)) == 1
+    @test (@constinferred quantum_dimension(q1)) == 1
 
     @test trivial(q1) == U1(0)
     @test trivial(U1) == U1(0)
@@ -65,7 +67,7 @@ using Test: @inferred, @test, @testset, @test_throws
 
     @test quantum_dimension(z0) == 1
     @test quantum_dimension(z1) == 1
-    @test (@inferred quantum_dimension(z0)) == 1
+    @test (@constinferred quantum_dimension(z0)) == 1
 
     @test dual(z0) == z0
     @test dual(z1) == z1
@@ -93,15 +95,15 @@ using Test: @inferred, @test, @testset, @test_throws
     @test trivial(O2) == s0e
     @test istrivial(s0e)
 
-    @test (@inferred quantum_dimension(s0e)) == 1
-    @test (@inferred quantum_dimension(s0o)) == 1
-    @test (@inferred quantum_dimension(s12)) == 2
-    @test (@inferred quantum_dimension(s1)) == 2
+    @test (@constinferred quantum_dimension(s0e)) == 1
+    @test (@constinferred quantum_dimension(s0o)) == 1
+    @test (@constinferred quantum_dimension(s12)) == 2
+    @test (@constinferred quantum_dimension(s1)) == 2
 
-    @test (@inferred dual(s0e)) == s0e
-    @test (@inferred dual(s0o)) == s0o
-    @test (@inferred dual(s12)) == s12
-    @test (@inferred dual(s1)) == s1
+    @test (@constinferred dual(s0e)) == s0e
+    @test (@constinferred dual(s0o)) == s0o
+    @test (@constinferred dual(s12)) == s12
+    @test (@constinferred dual(s1)) == s1
 
     @test s0o < s0e < s12 < s1
     @test s0e == TrivialSector()
@@ -133,7 +135,7 @@ using Test: @inferred, @test, @testset, @test_throws
     @test quantum_dimension(j2) == 2
     @test quantum_dimension(j3) == 3
     @test quantum_dimension(j4) == 4
-    @test (@inferred quantum_dimension(j1)) == 1
+    @test (@constinferred quantum_dimension(j1)) == 1
 
     @test dual(j1) == j1
     @test dual(j2) == j2
@@ -175,7 +177,7 @@ using Test: @inferred, @test, @testset, @test_throws
     @test quantum_dimension(SU{3}((3, 3))) == 10
     @test quantum_dimension(SU{3}((3, 0))) == 10
     @test quantum_dimension(SU{3}((0, 0))) == 1
-    @test (@inferred quantum_dimension(f3)) == 3
+    @test (@constinferred quantum_dimension(f3)) == 3
   end
 
   @testset "Fibonacci" begin
@@ -189,8 +191,8 @@ using Test: @inferred, @test, @testset, @test_throws
     @test dual(ı) == ı
     @test dual(τ) == τ
 
-    @test (@inferred quantum_dimension(ı)) == 1.0
-    @test (@inferred quantum_dimension(τ)) == ((1 + √5) / 2)
+    @test (@constinferred quantum_dimension(ı)) == 1.0
+    @test (@constinferred quantum_dimension(τ)) == ((1 + √5) / 2)
 
     @test ı < τ
   end
@@ -208,9 +210,9 @@ using Test: @inferred, @test, @testset, @test_throws
     @test dual(σ) == σ
     @test dual(ψ) == ψ
 
-    @test (@inferred quantum_dimension(ı)) == 1.0
-    @test (@inferred quantum_dimension(σ)) == √2
-    @test (@inferred quantum_dimension(ψ)) == 1.0
+    @test (@constinferred quantum_dimension(ı)) == 1.0
+    @test (@constinferred quantum_dimension(σ)) == √2
+    @test (@constinferred quantum_dimension(ψ)) == 1.0
 
     @test ı < σ < ψ
   end


### PR DESCRIPTION
This PR updates tests using `@constinferred` from `TestExtras`. It also removes empty `test_basics.`