### PR TITLE
Test `gradedrange` constructor with `SectorProduct` passed as `NamedTuple`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymmetrySectors"
 uuid = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/sector_product.jl
+++ b/src/sector_product.jl
@@ -236,3 +236,9 @@ function shared_arguments_fusion_rule(shared1::NT, shared2::NT) where {NT<:Named
   tuple_fused = shared_arguments_fusion_rule(values(shared1), values(shared2))
   return map_blocklabels(SectorProduct ∘ NT ∘ arguments ∘ SectorProduct, tuple_fused)
 end
+
+function GradedUnitRanges.gradedrange(
+  lblocklengths::AbstractVector{<:Pair{NT,<:Integer}}
+) where {NT<:NamedTuple{<:Any,<:Tuple{Vararg{AbstractSector}}}}
+  return gradedrange(map(SectorProduct, first.(lblocklengths)) .=> last.(lblocklengths))
+end

--- a/src/sector_product.jl
+++ b/src/sector_product.jl
@@ -236,9 +236,3 @@ function shared_arguments_fusion_rule(shared1::NT, shared2::NT) where {NT<:Named
   tuple_fused = shared_arguments_fusion_rule(values(shared1), values(shared2))
   return map_blocklabels(SectorProduct ∘ NT ∘ arguments ∘ SectorProduct, tuple_fused)
 end
-
-function GradedUnitRanges.gradedrange(
-  lblocklengths::AbstractVector{<:Pair{NT,<:Integer}}
-) where {NT<:NamedTuple{<:Any,<:Tuple{Vararg{AbstractSector}}}}
-  return gradedrange(map(SectorProduct, first.(lblocklengths)) .=> last.(lblocklengths))
-end

--- a/test/test_sector_product.jl
+++ b/test/test_sector_product.jl
@@ -13,7 +13,7 @@ using SymmetrySectors:
   quantum_dimension,
   arguments,
   trivial
-using GradedUnitRanges: dual, fusion_product, space_isequal, gradedrange
+using GradedUnitRanges: dual, fusion_product, space_isequal, gradedrange, sector_type
 using Test: @test, @testset, @test_throws
 using TestExtras: @constinferred
 
@@ -309,6 +309,9 @@ end
     s1 = (A=U1(1),) × (B=Z{2}(0),)
     s2 = (A=U1(1),) × (C=Z{2}(0),)
     @test_throws ArgumentError s1 × s2
+
+    g = gradedrange([(Nf=U1(0),) => 2, (Nf=U1(1),) => 3])
+    @test sector_type(g) <: SectorProduct
   end
 
   @testset "Construct from Pairs" begin


### PR DESCRIPTION
Fix https://github.com/ITensor/GradedUnitRanges.jl/issues/16