### PR TITLE
Add IntegrationTest workflow

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -1,0 +1,25 @@
+name: "IntegrationTest"
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+    paths:
+      - 'Project.toml'
+  pull_request:
+    paths:
+      - 'Project.toml'
+
+jobs:
+  integration-test:
+    name: "IntegrationTest"
+    strategy:
+       matrix:
+         repo:
+           - 'ITensor/BlockSparseArrays.jl'
+           - 'ITensor/QuantumOperatorDefinitions.jl'
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    with:
+      localregistry: "https://github.com/ITensor/ITensorRegistry.git"
+      repo: "${{ matrix.repo }}"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -19,6 +19,7 @@ jobs:
          repo:
            - 'ITensor/BlockSparseArrays.jl'
            - 'ITensor/QuantumOperatorDefinitions.jl'
+           - 'ITensor/TensorAlgebra.jl'
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -1,0 +1,14 @@
+name: "Integration Request"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  integrationrequest:
+    if: |
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+    uses: ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@main
+    with:
+      localregistry: https://github.com/ITensor/ITensorRegistry.git

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -1,0 +1,24 @@
+name: Register Package
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - 'Project.toml'
+    branches:
+      - 'master'
+      - 'main'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  Register:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@main"
+    with:
+      localregistry: ITensor/ITensorRegistry
+    secrets:
+      REGISTRATOR_KEY: ${{ secrets.REGISTRATOR_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymmetrySectors"
 uuid = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"


### PR DESCRIPTION
These weren't added as downstream tests before since they don't technically depend on SymmetrySectors.jl but SymmetrySectors.jl is used in their tests when constructing symmetric tensors.